### PR TITLE
bug/repeated order violates pk

### DIFF
--- a/services/src/main/java/ar/edu/itba/paw/services/OrderServiceImpl.java
+++ b/services/src/main/java/ar/edu/itba/paw/services/OrderServiceImpl.java
@@ -58,7 +58,7 @@ public class OrderServiceImpl implements OrderService {
       throw new IllegalArgumentException("Order quantity should be le than available quantity");
     }
 
-    Optional<Order> existantOrder = publication.getOrders().stream().filter(o -> o.getOrderer().equals(loggedUser)).findFirst();
+    Optional<Order> existantOrder = publication.getOrders().stream().filter(o -> o.getOrderer().equals(loggedUser.get())).findFirst();
 
     if(existantOrder.isPresent()) {
       /** The user already ordered from this publication, so we just update the quantity */


### PR DESCRIPTION
## Summary
**Problem:** Ordering repeatedly caused a pk violation
**Cause:** instead of adding the new order to the previous order, the api was trying to create a new one (with same pk) because orderer comparison was made with an optional without getting it.
**Solution:** add the missing `get` call