### PR TITLE
bug/event listeners without transactional context

### DIFF
--- a/services/src/main/java/ar/edu/itba/paw/services/listener/PublicationPurchasedListener.java
+++ b/services/src/main/java/ar/edu/itba/paw/services/listener/PublicationPurchasedListener.java
@@ -7,6 +7,7 @@ import ar.edu.itba.paw.model.events.PublicationPurchasedEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class PublicationPurchasedListener implements ApplicationListener<PublicationPurchasedEvent> {
@@ -15,6 +16,7 @@ public class PublicationPurchasedListener implements ApplicationListener<Publica
   private NotificationDao notificationDao;
 
   @Override
+  @Transactional
   public void onApplicationEvent(PublicationPurchasedEvent publicationPurchasedEvent) {
     Publication publication = publicationPurchasedEvent.getSource();
 

--- a/services/src/main/java/ar/edu/itba/paw/services/listener/SupervisorLeftListener.java
+++ b/services/src/main/java/ar/edu/itba/paw/services/listener/SupervisorLeftListener.java
@@ -7,6 +7,7 @@ import ar.edu.itba.paw.model.events.SupervisorLeftEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class SupervisorLeftListener implements ApplicationListener<SupervisorLeftEvent> {
@@ -15,11 +16,12 @@ public class SupervisorLeftListener implements ApplicationListener<SupervisorLef
   private NotificationDao notificationDao;
 
   @Override
+  @Transactional
   public void onApplicationEvent(SupervisorLeftEvent supervisorLeftEvent) {
     Publication publication = supervisorLeftEvent.getSource();
 
     // Notify orderers that the supervisor left
-    publication.getOrders().parallelStream().forEach(o -> {
+    publication.getOrders().forEach(o -> {
      notificationDao.create(o.getOrderer(), NotificationType.PUBLICATION_ORPHAN, publication, o, null);
     });
   }


### PR DESCRIPTION
## Summary
**Problem:** some event listeners where failing due to missing transactional context.
**Solution:** add `@Transactional` to failing event listeners and change parallelstreams to regular streams as they are runned in separate threads and thus, without a transactional context.